### PR TITLE
Be specific about where group storage is created

### DIFF
--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -40,6 +40,6 @@ unable to contact qmaster using port 6444 on host "q"
 
 **Q**. _Is it possible to have a common folder where our lab group members can share files and software?_
 
-**A1**. If you belong to a specific group, we can set up a `/wynton/home/your_group/shared/` folder that group members (part of the same Unix group) have write access to. Any such files will count toward the disk quota of the user who owns the files. The typical use case is then that one or more members maintain subdirectories therein.  If you need this, please drop us an email.  Note, if the `groups` command reports `lsd` for you, then you do not belong to a specific group and can unfortunately not get a group-specific folder.
+**A1**. If you belong to a specific group, we can set up a `/wynton/group/your_group/shared/` folder that group members (part of the same Unix group) have write access to. Any such files will count toward the disk quota of the user who owns the files. The typical use case is then that one or more members maintain subdirectories therein.  If you need this, please drop us an email.  Note, if the `groups` command reports `lsd` for you, then you do not belong to a specific group and can unfortunately not get a group-specific folder.
 
 **A2**. Labs who [purchase additional storage]({{ '/about/pricing-storage.html' | relative_url }}) will get a separate storage location of their own.  Files written to that location will not count toward users disk quota.

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -40,6 +40,6 @@ unable to contact qmaster using port 6444 on host "q"
 
 **Q**. _Is it possible to have a common folder where our lab group members can share files and software?_
 
-**A1**. If you belong to a specific group, we can set up a `/wynton/group/your_group/shared/` folder that group members (part of the same Unix group) have write access to. Any such files will count toward the disk quota of the user who owns the files. The typical use case is then that one or more members maintain subdirectories therein.  If you need this, please drop us an email.  Note, if the `groups` command reports `lsd` for you, then you do not belong to a specific group and can unfortunately not get a group-specific folder.
+**A1**. If you belong to a specific group, we can set up a `/wynton/home/your_group/shared/` folder that group members (part of the same Unix group) have write access to. Any such files will count toward the disk quota of the user who owns the files. The typical use case is then that one or more members maintain subdirectories therein.  If you need this, please drop us an email.  Note, if the `groups` command reports `lsd` for you, then you do not belong to a specific group and can unfortunately not get a group-specific folder.
 
-**A2**. Labs who [purchase additional storage]({{ '/about/pricing-storage.html' | relative_url }}) will get a separate storage location of their own.  Files written to that location will not count toward users disk quota.
+**A2**. Labs who [purchase additional storage]({{ '/about/pricing-storage.html' | relative_url }}) will get a `/wynton/group/your_group/` folder.  Files written in that folder will not count toward users disk quota.


### PR DESCRIPTION
Purchased lab storage goes in /wynton/group/.  Should we say anything about NFS servers in the PI zone?